### PR TITLE
Use app extension API only

### DIFF
--- a/iOS/Bagel.xcodeproj/project.pbxproj
+++ b/iOS/Bagel.xcodeproj/project.pbxproj
@@ -364,6 +364,7 @@
 		3760A43E21F13817004D1E07 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +395,7 @@
 		3760A43F21F13817004D1E07 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
Hi, 

when integrating Bagel into app extensions using Carthage, I always get a warning that Bagel is not safe to use in app extensions.

> ld: warning: linking against a dylib which is not safe for use in application extensions: /Users/.../Carthage/Build/iOS/Bagel.framework/Bagel

This could be simply fixed by checking a checkbox in general settings of Bagel target and that's exactly what this PR does.