### PR TITLE
RequestHeaders should be retrieved from the `currentRequest`

### DIFF
--- a/iOS/Source/BagelRequestCarrier.m
+++ b/iOS/Source/BagelRequestCarrier.m
@@ -86,14 +86,14 @@
     if (self.urlSessionTask) {
         
         requestInfo.url = self.urlSessionTask.originalRequest.URL;
-        requestInfo.requestHeaders = self.self.urlSessionTask.originalRequest.allHTTPHeaderFields;
+        requestInfo.requestHeaders = self.self.urlSessionTask.currentRequest.allHTTPHeaderFields;
         requestInfo.requestBody = self.self.urlSessionTask.originalRequest.HTTPBody;
         requestInfo.requestMethod = self.self.urlSessionTask.originalRequest.HTTPMethod;
         
     }else if (self.urlConnection) {
         
         requestInfo.url = self.urlConnection.originalRequest.URL;
-        requestInfo.requestHeaders = self.self.urlConnection.originalRequest.allHTTPHeaderFields;
+        requestInfo.requestHeaders = self.self.urlConnection.currentRequest.allHTTPHeaderFields;
         requestInfo.requestBody = self.self.urlConnection.originalRequest.HTTPBody;
         requestInfo.requestMethod = self.self.urlConnection.originalRequest.HTTPMethod;
         


### PR DESCRIPTION
As outlined within https://github.com/yagiz/Bagel/issues/33, URLSession automatically adds additional HTTP Headers to requests that are not observed by bagel.

Currently `BagelRequestCarrier.m` extracts `allHTTPHeaderFields` from the original request that is enqueued and not the current request that is transmitted over the network.

It can be assumed this is to avoid logging anything after receiving an `HTTP 301/2/3` redirect response, but a redirect will not cause any of the `allHTTPHeaderFields` to change so it is safe and preferred to log the headers from the `currentRequest`.

To be completely transparent about redirects, Bagel could swizzle `@selector(_redirectRequest:redirectResponse:completion:);` and log etc...


