### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Bagel",
+    products: [
+        .library(name: "Bagel", targets: ["Bagel"])
+    ],
+    targets: [
+        .target(
+            name: "Bagel",
+            path: "iOS/Source"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,13 @@ let package = Package(
     products: [
         .library(name: "Bagel", targets: ["Bagel"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/AccioSupport/CocoaAsyncSocket.git", .branch("master")),
+    ],
     targets: [
         .target(
             name: "Bagel",
+            dependencies: ["CocoaAsyncSocket"],
             path: "iOS/Source"
         )
     ]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
         <img src="https://img.shields.io/badge/CocoaPods-compatible-4BC51D.svg?style=flat" /></a>
     <a href="https://github.com/Carthage/Carthage" alt="Carthage">
         <img src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" /></a>
+    <a href="https://github.com/JamitLabs/Accio" alt="Accio">
+        <img src="https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat" /></a>
     <a href="https://github.com/yagiz/Bagel/releases" alt="Version">
         <img src="https://img.shields.io/github/release/yagiz/Bagel.svg" /></a>
 </p>
@@ -26,6 +28,10 @@ pod 'Bagel', '~>  1.3.2'
 ##### Carthage
 ```sh
 github "yagiz/Bagel" "1.3.2"
+```
+##### Accio
+```swift
+.package(url: "https://github.com/yagiz/Bagel.git", .upToNextMajor(from: "1.3.2")),
 ```
 
 ### Usage


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).