### PR TITLE
Move used headers into Public access

### DIFF
--- a/iOS/Bagel.xcodeproj/project.pbxproj
+++ b/iOS/Bagel.xcodeproj/project.pbxproj
@@ -19,14 +19,14 @@
 		3760A46421F1383F004D1E07 /* BagelBaseModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A44A21F1383F004D1E07 /* BagelBaseModel.m */; };
 		3760A46521F1383F004D1E07 /* BagelURLConnectionInjector.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A44B21F1383F004D1E07 /* BagelURLConnectionInjector.h */; };
 		3760A46621F1383F004D1E07 /* BagelBrowser.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A44C21F1383F004D1E07 /* BagelBrowser.m */; };
-		3760A46721F1383F004D1E07 /* BagelRequestPacket.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A44D21F1383F004D1E07 /* BagelRequestPacket.h */; };
+		3760A46721F1383F004D1E07 /* BagelRequestPacket.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A44D21F1383F004D1E07 /* BagelRequestPacket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3760A46821F1383F004D1E07 /* BagelController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A44E21F1383F004D1E07 /* BagelController.m */; };
 		3760A46921F1383F004D1E07 /* BagelRequestCarrier.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A44F21F1383F004D1E07 /* BagelRequestCarrier.h */; };
 		3760A46A21F1383F004D1E07 /* BagelDeviceModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45021F1383F004D1E07 /* BagelDeviceModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3760A46B21F1383F004D1E07 /* BagelProjectModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A45121F1383F004D1E07 /* BagelProjectModel.m */; };
 		3760A46C21F1383F004D1E07 /* BagelUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45221F1383F004D1E07 /* BagelUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3760A46D21F1383F004D1E07 /* BagelURLSessionInjector.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45321F1383F004D1E07 /* BagelURLSessionInjector.h */; };
-		3760A46E21F1383F004D1E07 /* BagelRequestInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45421F1383F004D1E07 /* BagelRequestInfo.h */; };
+		3760A46E21F1383F004D1E07 /* BagelRequestInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45421F1383F004D1E07 /* BagelRequestInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3760A46F21F1383F004D1E07 /* Bagel.h in Headers */ = {isa = PBXBuildFile; fileRef = 3760A45521F1383F004D1E07 /* Bagel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3760A47021F1383F004D1E07 /* BagelConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A45621F1383F004D1E07 /* BagelConfiguration.m */; };
 		3760A47121F1383F004D1E07 /* BagelRequestPacket.m in Sources */ = {isa = PBXBuildFile; fileRef = 3760A45721F1383F004D1E07 /* BagelRequestPacket.m */; };
@@ -154,8 +154,8 @@
 				3760A45D21F1383F004D1E07 /* BagelController.h in Headers */,
 				3760A47221F1383F004D1E07 /* BagelBrowser.h in Headers */,
 				3760A46021F1383F004D1E07 /* BagelConfiguration.h in Headers */,
-				3760A46E21F1383F004D1E07 /* BagelRequestInfo.h in Headers */,
 				3760A46921F1383F004D1E07 /* BagelRequestCarrier.h in Headers */,
+				3760A46E21F1383F004D1E07 /* BagelRequestInfo.h in Headers */,
 				3760A46721F1383F004D1E07 /* BagelRequestPacket.h in Headers */,
 				3760A46A21F1383F004D1E07 /* BagelDeviceModel.h in Headers */,
 				3760A46C21F1383F004D1E07 /* BagelUtility.h in Headers */,


### PR DESCRIPTION
In the xcode project, the BagelRequestPacket.h and BagelRequestInfo.h had a `project` accessing scope. They are imported from public headers, so i considered to move them to `public` accessing scope. It will fix the framework import when it is built by carthage / xcode