### PR TITLE
Cleanup URL formatting in JSON strings

### DIFF
--- a/mac/Bagel.xcodeproj/project.pbxproj
+++ b/mac/Bagel.xcodeproj/project.pbxproj
@@ -824,8 +824,6 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Bagel/Pods-Bagel-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaAsyncSocket/CocoaAsyncSocket.framework",
@@ -833,8 +831,6 @@
 				"${BUILT_PRODUCTS_DIR}/macOSThemeKit/macOSThemeKit.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaAsyncSocket.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Highlightr.framework",

--- a/mac/Bagel/Workers/ContentRepresentation/ContentRepresentation/DataRepresentation/DataRepresentationParser.swift
+++ b/mac/Bagel/Workers/ContentRepresentation/ContentRepresentation/DataRepresentation/DataRepresentationParser.swift
@@ -36,7 +36,7 @@ class DataRepresentationParser {
                 if let jsonString = String(data: jsonData, encoding: .utf8) {
                     
                     let jsonData = DataJSONRepresentation(data: data)
-                    jsonData.rawString = jsonString
+                    jsonData.rawString = jsonString.replacingOccurrences(of: "\\/", with: "/")
                     return jsonData
                 }
             }

--- a/mac/Podfile.lock
+++ b/mac/Podfile.lock
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - macOSThemeKit (~> 1.2.0)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - CocoaAsyncSocket
     - Highlightr
     - macOSThemeKit
@@ -21,4 +21,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6e39cacd4a77b09b958e2e6f8b405bbc2340dfc2
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.8.4


### PR DESCRIPTION
Replaces escaped slashes in URLs (eg. `http:\/\/google.com`) with unescaped slashed (eg. `http://google.com`)