### PR TITLE
Stop `resume` swizzling

### DIFF
--- a/iOS/Source/BagelURLSessionInjector.m
+++ b/iOS/Source/BagelURLSessionInjector.m
@@ -82,7 +82,7 @@
     }
 
     if (taskClass) {
-        [self swizzleSessionTaskResume:taskClass];
+//        [self swizzleSessionTaskResume:taskClass];
     }
 }
 


### PR DESCRIPTION
## Why

SDWebImage で画像をロードすると `resume` を swizzle している箇所でクラッシュする

## What

`resume` を止めても Bagel browser は使えるのでコメントアウトする

ref: https://github.com/wantedly/yashima-ios/issues/8477 (Internal Only)